### PR TITLE
b0.9.1 Fix a condition that caused Firmata.js to hang when using a stripped Arduino Firmata.

### DIFF
--- a/examples/DemoHelloAPI.js
+++ b/examples/DemoHelloAPI.js
@@ -35,7 +35,7 @@ let opts;
 // Set up
 
 const init = () => {
-  opts = {};
+  opts = {skipCapabilities: true};
   firmataBoard = new firmata.Board(portName,opts,() => {
     log.debug(`Board is ready.`);
 

--- a/examples/DemoMCP9808API.js
+++ b/examples/DemoMCP9808API.js
@@ -35,7 +35,7 @@ let opts;
 // Set up
 
 const init = () => {
-  opts = {};
+  opts = {skipCapabilities: true};
   firmataBoard = new firmata.Board(portName,opts,() => {
     log.debug(`Board is ready.`);
 

--- a/examples/DemoMetaAPI.js
+++ b/examples/DemoMetaAPI.js
@@ -35,7 +35,7 @@ let opts;
 // Set up
 
 const init = () => {
-  opts = {};
+  opts = {skipCapabilities: true};
   firmataBoard = new firmata.Board(portName,opts,() => {
     log.debug(`Board is ready.`);
 

--- a/examples/DemoServoAPI.js
+++ b/examples/DemoServoAPI.js
@@ -82,7 +82,7 @@ let step = [
 (apiResult) => {
   log.info(`Opened ${apiResult.unitName} with handle ${apiResult.handle}.`);
   handle = apiResult.handle;
-  log.debug(`Mode check: isServo(3) is ${firmataBoard.pins.isServo(3)}`);
+  // log.debug(`Mode check: isServo(3) is ${firmataBoard.pins.isServo(3)}`);
   api.attach(handle,3,{});
 },
 

--- a/examples/DemoServoAPI.js
+++ b/examples/DemoServoAPI.js
@@ -35,7 +35,7 @@ let opts;
 // Set up
 
 const init = () => {
-  opts = {};
+  opts = {skipCapabilities: true};
   firmataBoard = new firmata.Board(portName,opts,() => {
     log.debug(`Board is ready.`);
 

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
       "RemoteDeviceDriver"
    ],
    "license" : "GPL-3.0",
-   "main" : "lunijs.js",
+   "main" : "lib/RDD/RemoteDeviceDriver.js",
    "name" : "lunijs",
    "repository" : {
       "type" : "git",
       "url" : "https://github.com/finson-release/LuniJS"
    },
    "scripts" : {},
-   "version" : "0.9.0"
+   "version" : "0.9.1"
 }


### PR DESCRIPTION
If all features except DeviceFirmata are excluded on the Arduino, then the AnalogMapping request fails to return a satisfactory answer to firmata.js and it hangs.
